### PR TITLE
Let swupdate Makefile know about MTD versions.:

### DIFF
--- a/swupdate/Makefile
+++ b/swupdate/Makefile
@@ -7,7 +7,7 @@ PKG_RELEASE:=$(AUTORELEASE)
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=https://github.com/sbabic/swupdate/archive/$(PKG_VERSION)
 PKG_HASH:=5afe78ae94e869bcb911d8592251641cdab80096d8e5149d483054ea49f9aab8
-
+MTD_VERSION_DIR:=$(notdir $(wildcard $(BUILD_DIR)/mtd-*))
 PKG_MAINTAINER:=Wambui Karuga <wambui@janga.la>
 
 PKG_BUILD_DEPENDS:=mtd-utils
@@ -16,7 +16,8 @@ include $(INCLUDE_DIR)/package.mk
 define Build/Prepare
 	$(Build/Prepare/Default)
 	$(INSTALL_DIR) $(STAGING_DIR)/usr/include/mtd/
-	$(CP) -R $(TOPDIR)/build_dir/host/mtd-utils-2.1.2/include/* $(STAGING_DIR)/usr/include/
+	echo $(MTD_VERSION_DIR)
+	$(CP) -R $(TOPDIR)/build_dir/host/$(MTD_VERSION_DIR)/include/* $(STAGING_DIR)/usr/include/
 endef
 
 define Package/swupdate
@@ -31,7 +32,7 @@ TARGET_CFLAGS += \
 	-I$(STAGING_DIR)/usr/include/mtd/mtd \
 	-I$(STAGING_DIR)/usr/include
 TARGET_LDFLAGS += \
-	-L$(BUILD_DIR)/mtd-utils-2.1.2
+	-L$(BUILD_DIR)/$(MTD_VERSION_DIR)
 
 MAKE_FLAGS += \
 	CFLAGS="$(TARGET_CFLAGS)" \


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Description

This PR makes the build of swupdate insensitive to the version of mtd-utils, since later versions of openwrt use a newer mtd-utils


## Related Issues, Tickets & Documents


## Screenshots/Recordings

<!-- Visual changes require screenshots -->

<!--
Have you manually tested this code and confirmed it is working?
-->
## Manual test
- [x] 👍 yes
- [ ] 🙅 no

## Added tests?

- [ ] 👍 yes
- [ ] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

